### PR TITLE
Add methods to update form data manually (closes #41)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build/
 
 # Misc
 .DS_Store
+
+.idea

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "reacto-form",
-  "version": "0.0.0-development",
+  "name": "@gwhobbs/reacto-form",
+  "version": "0.0.3-development",
   "description": "A React form state manager hook designed to work with many popular form UI frameworks",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/longshotlabs/reacto-form.git"
+    "url": "git+https://github.com/gwhobbs/reacto-form.git"
   },
   "keywords": [],
   "author": "Long Shot Labs (longshotlabs.co)",
@@ -88,7 +88,7 @@
     "typescript": "^4.6.4"
   },
   "peerDependencies": {
-    "react": ">=17 | >=18"
+    "react": "^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "lodash": "^4.17.21",

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,7 @@ export interface UseReactoFormState {
   getErrors: (fieldPaths: string[], options?: ErrorOptions) => ValidationError[]
   getFirstError: (fieldPaths: string[], options?: ErrorOptions) => ValidationError | null
   getFirstErrorMessage: (fieldPaths: string[], options?: ErrorOptions) => string | null
+  updateFormData: (formData: FormData) => void
   getInputProps: (fieldPath: string, options?: GetInputPropsOptions) => Record<string, any>
   hasBeenValidated: boolean
   hasErrors: (fieldPaths: string[], options?: ErrorOptions) => boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export interface GetInputPropsOptions {
   nullValue?: any
   onChangeGetValue?: (...args: any[]) => any
   onChangingGetValue?: (...args: any[]) => any
+  onApplyChangeToForm?: (formData: FormData, fieldValue: any, fieldPath: string) => FormData,
   propNames?: Partial<InputPropNameMap>
 }
 

--- a/src/useReactoForm.ts
+++ b/src/useReactoForm.ts
@@ -195,7 +195,8 @@ export default function useReactoForm (props: UseReactoFormProps): UseReactoForm
         isForm = false,
         nullValue,
         onChangeGetValue,
-        onChangingGetValue
+        onChangingGetValue,
+        onApplyChangeToForm,
       } = getInputPropsOptions
 
       const propNames: InputPropNameMap = { ...DEFAULT_PROP_NAMES }
@@ -230,7 +231,9 @@ export default function useReactoForm (props: UseReactoFormProps): UseReactoForm
           ? onChangeGetValue(...onChangeArgs)
           : onChangeArgs[0]
 
-        const updatedFormData = setFieldValueInFormData(fieldPath, inputValue)
+        const updatedFormData = (onApplyChangeToForm != null)
+          ? onApplyChangeToForm(clone(formData), inputValue, fieldPath)
+          : setFieldValueInFormData(fieldPath, inputValue)
 
         // Now bubble up the `onChange`, possibly validating first
         if (

--- a/src/useReactoForm.ts
+++ b/src/useReactoForm.ts
@@ -213,7 +213,8 @@ export default function useReactoForm (props: UseReactoFormProps): UseReactoForm
         (hasBeenValidated &&
           (revalidateOn === 'changed' || revalidateOn === 'changing'))
 
-      applyValueChange(formData, isValidationRequired);
+      setFormData(formData)
+      applyValueChange(formData, isValidationRequired)
     },
     getInputProps (fieldPath, getInputPropsOptions = {}) {
       const {


### PR DESCRIPTION
Sometimes it's helpful to be able to update form data manually. For example, maybe:
* We might want changing one field to affect the values of other fields (e.g. an array of values that must add to 100)
* We might want a button that causes predefined changes to happen to the form data (e.g. a button that alters existing items in an array)

This PR experimentally adds two new features addressing these issues:
1. A custom `onApplyChangeToForm(formData: FormData, fieldValue: any, fieldPath: string) => FormData` updater function can be provided as an option in `getInputProps()`
2. An `updateFormData(formData: FormData) => void` function is exposed for making arbitrary changes to the form data.